### PR TITLE
Run additional args with exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Wait until an address become available.
 - **-v**: Show the current version
 - **-file**: Path to the JSON file with the configs
 
+All additional parameters will be executed on the os when the address became available.
 
 ### Example
 
@@ -35,6 +36,8 @@ waitforit -full-connection=tcp://google.com:90 -timeout=20 -debug
 waitforit -full-connection=http://google.com -timeout=20 -debug
 
 waitforit -full-connection=http://google.com:90 -timeout=20 -debug
+
+waitforit -full-connection=http://google.com -timeout=20 -debug printf "Google Works\!"
 ```
 
 #### Using with config file

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 )
 
 // VERSION is definded during the build
@@ -25,6 +26,12 @@ type FileConfig struct {
 }
 
 func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage:\n\n  %s [options] [post-command]\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "The options are:\n\n")
+		flag.PrintDefaults()
+	}
+
 	fullConn := flag.String("full-connection", "", "full connection")
 	host := flag.String("host", "", "host to connect")
 	port := flag.Int("port", 80, "port to connect")
@@ -68,6 +75,24 @@ func main() {
 	if err := DialConfigs(fc.Configs, print); err != nil {
 		log.Fatal(err)
 	}
+
+	if err := runPostCommand(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func runPostCommand() error {
+	args := flag.Args()
+
+	if len(args) == 0 {
+		return nil
+	}
+
+	cmd := exec.Command(args[0], args[1:len(args)]...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+
+	return cmd.Run()
 }
 
 func loadFileConfig(path string, fc *FileConfig) error {


### PR DESCRIPTION
Add possibility to run commands within `waitforit`.

```bash
$ waitforit -full-connection=tcp://google.com:80 -timeout=30 -debug printf "Hello,\nWorld\!\n"
2017/08/19 15:22:23 Waiting 30 seconds
2017/08/19 15:22:23 Dial address: google.com:80
2017/08/19 15:22:24 ping TCP: google.com:80
2017/08/19 15:22:24 Up: google.com:80
Hello,
World!
```

```
Usage:

  waitforit [options] [post-command]

The options are:

  -debug
        enable debug
  -file string
        path of json file to read configs from
  -full-connection string
        full connection
  -host string
        host to connect
  -port int
        port to connect (default 80)
  -timeout int
        time to wait until port become available (default 10)
  -v    show the current version
```