### PR TITLE
Use address argument instead of full-connection if address is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Wait until an address become available.
 
 ### Options
 
-- **-address**: Address `<protocol/scheme>://<host>:<port>` (former **full-connection**)
-- **-host**: Host to connect
-- **-port**: Port to connect (default 80)
-- **-timeout**: Time to wait until the address become available
-- **-debug**: Enable debug
-- **-v**: Show the current version
-- **-file**: Path to the JSON file with the configs
-- **-- **: Execute a post command once the address became available
+- `-address`: Address (e.g. http://google.com or tcp://mysql_ip:mysql_port) - *former **full-connection***
+- `-host`: Host to connect
+- `-port`: Port to connect (default 80)
+- `-timeout`: Time to wait until the address become available
+- `-debug`: Enable debug
+- `-v`: Show the current version
+- `-file`: Path to the JSON file with the configs
+- `-- `: Execute a post command once the address became available
 
 > `full-connection` still working and won't be removed to not cause any API breaking change.
 > But please use `address` instead since it express the same thing in a simple way.
@@ -39,7 +39,7 @@ waitforit -address=http://google.com -timeout=20 -debug
 
 waitforit -address=http://google.com:90 -timeout=20 -debug
 
-waitforit -address=http://google.com -timeout=20 -debug -- echo "Google Works!"
+waitforit -address=http://google.com -timeout=20 -debug -- printf "Google Works\!"
 ```
 
 #### Using with config file

--- a/README.md
+++ b/README.md
@@ -14,14 +14,17 @@ Wait until an address become available.
 
 ### Options
 
-- **-full-connection**: Full connection `<protocol/scheme>://<host>:<port>`
+- **-address**: Address `<protocol/scheme>://<host>:<port>` (former **full-connection**)
 - **-host**: Host to connect
 - **-port**: Port to connect (default 80)
-- **-timeout**: Time to wait until port become available
+- **-timeout**: Time to wait until the address become available
 - **-debug**: Enable debug
 - **-v**: Show the current version
 - **-file**: Path to the JSON file with the configs
 - **-- **: Execute a post command once the address became available
+
+> `full-connection` still working and won't be removed to not cause any API breaking change.
+> But please use `address` instead since it express the same thing in a simple way.
 
 ### Example
 
@@ -30,13 +33,13 @@ Wait until an address become available.
 ```bash
 waitforit -host=google.com -port=90 -timeout=20 -debug
 
-waitforit -full-connection=tcp://google.com:90 -timeout=20 -debug
+waitforit -address=tcp://google.com:90 -timeout=20 -debug
 
-waitforit -full-connection=http://google.com -timeout=20 -debug
+waitforit -address=http://google.com -timeout=20 -debug
 
-waitforit -full-connection=http://google.com:90 -timeout=20 -debug
+waitforit -address=http://google.com:90 -timeout=20 -debug
 
-waitforit -full-connection=http://google.com -timeout=20 -debug -- echo "Google Works!"
+waitforit -address=http://google.com -timeout=20 -debug -- echo "Google Works!"
 ```
 
 #### Using with config file
@@ -53,7 +56,7 @@ Example JSON:
       "timeout": 20
     },
     {
-      "fullConnection": "http://google.com:80",
+      "address": "http://google.com:80",
       "timeout": 40
     }
   ]

--- a/connection.go
+++ b/connection.go
@@ -20,16 +20,21 @@ type Connection struct {
 // BuildConn build a connection structure.
 // This connection data can later be used as a common structure
 // by the functions that will check if the target is available.
-func BuildConn(host string, port int, fullConn string) *Connection {
-	if host != "" {
-		return &Connection{Type: "tcp", Host: host, Port: port}
+func BuildConn(cfg *Config) *Connection {
+	if cfg.Host != "" {
+		return &Connection{Type: "tcp", Host: cfg.Host, Port: cfg.Port}
 	}
 
-	if fullConn == "" {
+	address := cfg.Address
+	if address == "" {
+		// compatibilty with old argument
+		address = cfg.FullConn
+	}
+	if address == "" {
 		return nil
 	}
 
-	match := regexp.MustCompile(regexAddressConn).FindAllStringSubmatch(fullConn, -1)
+	match := regexp.MustCompile(regexAddressConn).FindAllStringSubmatch(address, -1)
 	if len(match) < 1 {
 		return nil
 	}

--- a/connection_test.go
+++ b/connection_test.go
@@ -72,7 +72,12 @@ func TestBuildConn(t *testing.T) {
 	}
 
 	for _, v := range testCases {
-		conn := BuildConn(v.data.host, v.data.port, v.data.fullConn)
+		cfg := &Config{
+			Host:    v.data.host,
+			Port:    v.data.port,
+			Address: v.data.fullConn,
+		}
+		conn := BuildConn(cfg)
 		t.Run(v.title, func(t *testing.T) {
 			if !reflect.DeepEqual(conn, v.expected) {
 				t.Errorf("Expected to %#v to be deep equal %#v", conn, v.expected)

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ var VERSION string
 type Config struct {
 	Host     string `json:"host"`
 	Port     int    `json:"port"`
+	Address  string `json:"address"`
 	FullConn string `json:"fullConnection"`
 	Timeout  int    `json:"timeout"`
 }
@@ -32,10 +33,11 @@ func main() {
 		flag.PrintDefaults()
 	}
 
-	fullConn := flag.String("full-connection", "", "full connection")
+	address := flag.String("address", "", "address")
+	fullConn := flag.String("full-connection", "", "full connection (please use address instead)")
 	host := flag.String("host", "", "host to connect")
 	port := flag.Int("port", 80, "port to connect")
-	timeout := flag.Int("timeout", 10, "time to wait until port become available")
+	timeout := flag.Int("timeout", 10, "time to wait until the address become available")
 	printVersion := flag.Bool("v", false, "show the current version")
 	debug := flag.Bool("debug", false, "enable debug")
 	file := flag.String("file", "", "path of json file to read configs from")
@@ -65,6 +67,7 @@ func main() {
 				{
 					Host:     *host,
 					Port:     *port,
+					Address:  *address,
 					FullConn: *fullConn,
 					Timeout:  *timeout,
 				},

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 		flag.PrintDefaults()
 	}
 
-	address := flag.String("address", "", "address")
+	address := flag.String("address", "", "address (e.g. http://google.com or tcp://mysql_ip:mysql_port)")
 	fullConn := flag.String("full-connection", "", "full connection (please use address instead)")
 	host := flag.String("host", "", "host to connect")
 	port := flag.Int("port", 80, "port to connect")

--- a/network.go
+++ b/network.go
@@ -14,7 +14,7 @@ func DialConfigs(confs []Config, print func(a ...interface{})) error {
 	ch := make(chan error)
 	for _, config := range confs {
 		go func(conf Config) {
-			conn := BuildConn(conf.Host, conf.Port, conf.FullConn)
+			conn := BuildConn(&conf)
 			if conn == nil {
 				ch <- fmt.Errorf("Invalid connection %#v", conf)
 				return

--- a/network_test.go
+++ b/network_test.go
@@ -253,7 +253,7 @@ func TestDialConfigs(t *testing.T) {
 					finishAllOk = false
 				}
 
-				conn := BuildConn(item.conf.Host, item.conf.Port, item.conf.FullConn)
+				conn := BuildConn(&item.conf)
 
 				s := NewServer(conn, item.serverHanlder)
 				defer s.Close()


### PR DESCRIPTION
Since the beginning I wasn't glad with the `full-connection` argument name. I believe just `address` has the same meaning and it is simpler. My intention isn't to deprecate `full-connection` to not cause a breaking change for anyone. But `address` will be the default argument for the address information and `full-connection` will only be used if `address` isn't defined.