### PR TITLE
Provide ability to expect specific status

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Wait until an address become available.
 ### Options
 
 - `-address`: Address (e.g. http://google.com or tcp://mysql_ip:mysql_port) - *former **full-connection***
+- `-status`: Expected status that address should return (e.g. 200)
 - `-host`: Host to connect
 - `-port`: Port to connect (default 80)
 - `-timeout`: Seconds to wait until the address become available
@@ -73,7 +74,7 @@ waitforit -file=./config.json
 ```
 FROM node:6.5.0
 
-ENV WAITFORIT_VERSION="v1.3.1"
+ENV WAITFORIT_VERSION="v2.2.1"
 RUN curl -o /usr/local/bin/waitforit -sSL https://github.com/maxcnunes/waitforit/releases/download/$WAITFORIT_VERSION/waitforit-linux_amd64 && \
     chmod +x /usr/local/bin/waitforit
 ```
@@ -83,7 +84,7 @@ RUN curl -o /usr/local/bin/waitforit -sSL https://github.com/maxcnunes/waitforit
 ```
 FROM node:6.5.0
 
-ENV WAITFORIT_VERSION="v1.3.1"
+ENV WAITFORIT_VERSION="v2.2.1"
 RUN wget -q -O /usr/local/bin/waitforit https://github.com/maxcnunes/waitforit/releases/download/$WAITFORIT_VERSION/waitforit-linux_amd64 \
     && chmod +x /usr/local/bin/waitforit
 ```

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ type Config struct {
 	Host    string `json:"host"`
 	Port    int    `json:"port"`
 	Address string `json:"address"`
+	Status  int    `json:"status"`
 	Timeout int    `json:"timeout"`
 	Retry   int    `json:"retry"`
 }
@@ -34,6 +35,7 @@ func main() {
 	}
 
 	address := flag.String("address", "", "address (e.g. http://google.com or tcp://mysql_ip:mysql_port)")
+	status := flag.Int("status", 0, "expected status that address should return (e.g. 200")
 	host := flag.String("host", "", "host to connect")
 	port := flag.Int("port", 80, "port to connect")
 	timeout := flag.Int("timeout", 10, "seconds to wait until the address become available")
@@ -74,6 +76,7 @@ func main() {
 					Host:    *host,
 					Port:    *port,
 					Address: *address,
+					Status:  *status,
 					Timeout: *timeout,
 					Retry:   *retry,
 				},

--- a/network.go
+++ b/network.go
@@ -20,7 +20,7 @@ func DialConfigs(confs []Config, print func(a ...interface{})) error {
 				return
 			}
 
-			ch <- DialConn(conn, conf.Timeout, conf.Retry, print)
+			ch <- DialConn(conn, conf.Timeout, conf.Retry, conf.Status, print)
 		}(config)
 	}
 
@@ -34,7 +34,7 @@ func DialConfigs(confs []Config, print func(a ...interface{})) error {
 }
 
 // DialConn check if the connection is available
-func DialConn(conn *Connection, timeoutSeconds int, retryMseconds int, print func(a ...interface{})) error {
+func DialConn(conn *Connection, timeoutSeconds int, retryMseconds int, status int, print func(a ...interface{})) error {
 	print("Waiting " + strconv.Itoa(timeoutSeconds) + " seconds")
 	if err := pingTCP(conn, timeoutSeconds, retryMseconds, print); err != nil {
 		return err
@@ -44,14 +44,17 @@ func DialConn(conn *Connection, timeoutSeconds int, retryMseconds int, print fun
 		return nil
 	}
 
-	return pingHTTP(conn, timeoutSeconds, retryMseconds, print)
+	return pingHTTP(conn, timeoutSeconds, retryMseconds, status, print)
 }
 
-func pingHTTP(conn *Connection, timeoutSeconds int, retryMseconds int, print func(a ...interface{})) error {
+func pingHTTP(conn *Connection, timeoutSeconds int, retryMseconds int, status int, print func(a ...interface{})) error {
 	timeout := time.Duration(timeoutSeconds) * time.Second
 	start := time.Now()
 	address := fmt.Sprintf("%s://%s:%d%s", conn.Scheme, conn.Host, conn.Port, conn.Path)
 	print("HTTP address: " + address)
+	if status > 0 {
+		print("Expect HTTP status" + strconv.Itoa(status))
+	}
 
 	for {
 		resp, err := http.Get(address)
@@ -60,8 +63,12 @@ func pingHTTP(conn *Connection, timeoutSeconds int, retryMseconds int, print fun
 			print("ping HTTP " + address + " " + resp.Status)
 		}
 
-		if err == nil && resp.StatusCode < http.StatusInternalServerError {
-			return nil
+		if err == nil {
+			if status > 0 && status == resp.StatusCode {
+				return nil
+			} else if status == 0 && resp.StatusCode < http.StatusInternalServerError {
+				return nil
+			}
 		}
 
 		if time.Since(start) > timeout {

--- a/network_test.go
+++ b/network_test.go
@@ -69,6 +69,7 @@ func TestDialConn(t *testing.T) {
 	testCases := []struct {
 		title         string
 		conn          Connection
+		status        int
 		allowStart    bool
 		openConnAfter int
 		finishOk      bool
@@ -77,6 +78,7 @@ func TestDialConn(t *testing.T) {
 		{
 			title:         "Should successfully check connection that is already available.",
 			conn:          Connection{Type: "tcp", Scheme: "", Port: 8080, Host: "localhost", Path: ""},
+			status:        0,
 			allowStart:    true,
 			openConnAfter: 0,
 			finishOk:      true,
@@ -85,6 +87,7 @@ func TestDialConn(t *testing.T) {
 		{
 			title:         "Should successfully check connection that open before reach the timeout.",
 			conn:          Connection{Type: "tcp", Scheme: "", Port: 8080, Host: "localhost", Path: ""},
+			status:        0,
 			allowStart:    true,
 			openConnAfter: 2,
 			finishOk:      true,
@@ -93,6 +96,7 @@ func TestDialConn(t *testing.T) {
 		{
 			title:         "Should successfully check a HTTP connection that is already available.",
 			conn:          Connection{Type: "tcp", Scheme: "http", Port: 8080, Host: "localhost", Path: ""},
+			status:        0,
 			allowStart:    true,
 			openConnAfter: 0,
 			finishOk:      true,
@@ -101,6 +105,7 @@ func TestDialConn(t *testing.T) {
 		{
 			title:         "Should successfully check a HTTP connection that open before reach the timeout.",
 			conn:          Connection{Type: "tcp", Scheme: "http", Port: 8080, Host: "localhost", Path: ""},
+			status:        0,
 			allowStart:    true,
 			openConnAfter: 2,
 			finishOk:      true,
@@ -109,6 +114,7 @@ func TestDialConn(t *testing.T) {
 		{
 			title:         "Should successfully check a HTTP connection that returns 404 status code.",
 			conn:          Connection{Type: "tcp", Scheme: "http", Port: 8080, Host: "localhost", Path: ""},
+			status:        0,
 			allowStart:    true,
 			openConnAfter: 0,
 			finishOk:      true,
@@ -119,11 +125,34 @@ func TestDialConn(t *testing.T) {
 		{
 			title:         "Should fail checking a HTTP connection that returns 500 status code.",
 			conn:          Connection{Type: "tcp", Scheme: "http", Port: 8080, Host: "localhost", Path: ""},
+			status:        0,
 			allowStart:    true,
 			openConnAfter: 0,
 			finishOk:      false,
 			serverHanlder: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "", 500)
+			}),
+		},
+		{
+			title:         "Should successfully check a HTTP connection that returns 200 status code before reach the timeout.",
+			conn:          Connection{Type: "tcp", Scheme: "http", Port: 8080, Host: "localhost", Path: ""},
+			status:        200,
+			allowStart:    true,
+			openConnAfter: 2,
+			finishOk:      true,
+			serverHanlder: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte("OK"))
+			}),
+		},
+		{
+			title:         "Should fail checking a HTTP connection that returns not expected status code.",
+			conn:          Connection{Type: "tcp", Scheme: "http", Port: 8080, Host: "localhost", Path: ""},
+			status:        200,
+			allowStart:    true,
+			openConnAfter: 0,
+			finishOk:      false,
+			serverHanlder: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "", 404)
 			}),
 		},
 	}
@@ -148,7 +177,7 @@ func TestDialConn(t *testing.T) {
 				}()
 			}
 
-			err = DialConn(&v.conn, defaultTimeout, defaultRetry, print)
+			err = DialConn(&v.conn, defaultTimeout, defaultRetry, v.status, print)
 			if err != nil && v.finishOk {
 				t.Errorf("Expected to connect successfully %#v. But got error %v.", v.conn, err)
 				return


### PR DESCRIPTION
Hi @maxcnunes 

Could you please merge this PR?. It that provides an ability to expect address to return specific status code. Also I updated `Installing with a Dockerfile` section in README because when I tried it for the first time I found that `address` is not supported and only then I found that I use `1.3.1` but latest was `2.2.0`

`status` is a new optional parameter that accept http status code. When `status` is set, the tool waits this status code to exit successfully

