### PR TITLE
Improve headers parsing - fix #24

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,11 +95,11 @@ func main() { // nolint gocyclo
 		headers := make(map[string]string)
 		if len(fheaders) > 0 {
 			for _, v := range fheaders {
-				result := strings.SplitN(v, ":", 2)
+				result := strings.SplitN(v, ": ", 2)
 				if len(result) != 2 {
 					continue
 				}
-				headers[result[0]] = result[1]
+				headers[result[0]] = strings.TrimLeft(result[1], " ")
 			}
 		}
 


### PR DESCRIPTION
Headers seems to be on the format `<key>: <value>`

Fix will split on the pattern `: ` and then would remove any space on the left side of the 2nd element.

Ex:

```
Authorization: Basic MyEncodedCredentials
```
Split will generate : `Authrorization` & `Basic MyEncodedCredentials`
Trimleft will do nothing more in this case

```
Authorization:     Basic MyEncodedCredentials
```
Split will generate : `Authrorization` & `    Basic MyEncodedCredentials`
Trimleft will generate: `Basic MyEncodedCredentials`
