### PR TITLE
Fix unchecked error/panic

### DIFF
--- a/network.go
+++ b/network.go
@@ -90,6 +90,9 @@ func pingAddress(conn *Connection, conf *Config, print func(a ...interface{})) e
 		}
 
 		if time.Since(start) > timeout {
+			if err != nil {
+				return err
+			}
 			return errors.New(resp.Status)
 		}
 


### PR DESCRIPTION
Fixes #30

This occurs either when caused by client policy (such as CheckRedirect), or failure to speak HTTP (such as a network connectivity problem). A non-2xx status code doesn't cause an error.