### PR TITLE
Fix release link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Wait until an address become available.
 
 ### Download
 
-[Releases](https://github.com/maxcnunes/waitforit/releases)
+[Releases](https://github.com/maxclaus/waitforit/releases)
 
 ### Options
 


### PR DESCRIPTION
Link to the release page for the active repository, rather than the archived one. Note that the archived release page no longer has any releases.